### PR TITLE
reader: do not crash on empty page

### DIFF
--- a/nuber/reader.py
+++ b/nuber/reader.py
@@ -409,7 +409,11 @@ class Reader:
             self.offset = offset
         self.pad.refresh(self.offset, 0, 0, 0, self.rows - 1, self.cols - 1)
 
-        percentage_str = f"{self.progress * 100 // sum(self.lines)}%"
+        if self.lines <= 0:
+          percentage_str = "100%"
+        else:
+          percentage_str = f"{self.progress * 100 // sum(self.lines)}%"
+
         self.percentage_win.addstr(0, 4 - len(percentage_str), percentage_str, curses.A_BOLD)
         self.percentage_win.refresh()
         with canvas.synchronous_lazy_drawing:


### PR DESCRIPTION
While testing the application, I ran over a division by 0 error.
This should fix it.